### PR TITLE
feat: process multi instructions transactions

### DIFF
--- a/crates/seashell-core/Cargo.toml
+++ b/crates/seashell-core/Cargo.toml
@@ -19,6 +19,10 @@ path = "tests/create-account.rs"
 name = "sysvar-ixns"
 path = "tests/sysvar-ixns.rs"
 
+[[test]]
+name = "process-instructions-sysvar"
+path = "tests/process_instructions_sysvar.rs"
+
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-precompiles = { workspace = true }

--- a/crates/seashell-core/src/accounts_db.rs
+++ b/crates/seashell-core/src/accounts_db.rs
@@ -59,18 +59,34 @@ impl AccountsDb {
     }
 
     pub fn account_must(&self, pubkey: &Pubkey) -> AccountSharedData {
-        self.account_maybe(pubkey).unwrap_or_else(|| {
-            #[cfg(feature = "rpc-fetch")]
-            {
-                self.scenario
-                    .try_fetch_from_rpc(pubkey)
-                    .expect("Account not found")
+        self.resolve_account(pubkey, false)
+    }
+
+    /// Resolve a single account by pubkey following the standard lookup order:
+    /// local cache, then RPC fallback, then uninitialized-account fallback if
+    /// `allow_uninitialized_accounts` is set. Panics if none of the above succeed.
+    pub fn resolve_account(
+        &self,
+        pubkey: &Pubkey,
+        allow_uninitialized_accounts: bool,
+    ) -> AccountSharedData {
+        if let Some(account) = self.account_maybe(pubkey) {
+            return account;
+        }
+
+        #[cfg(feature = "rpc-fetch")]
+        if self.scenario.rpc_enabled() {
+            if let Some(account) = self.scenario.try_fetch_from_rpc(pubkey) {
+                return account;
             }
-            #[cfg(not(feature = "rpc-fetch"))]
-            {
-                panic!("Account not found for {pubkey}")
-            }
-        })
+        }
+
+        if allow_uninitialized_accounts {
+            log::debug!("Creating uninitialized account for {pubkey}");
+            return AccountSharedData::default();
+        }
+
+        panic!("Account not found for {pubkey}");
     }
 
     /// Panics if unable to find any account.
@@ -82,39 +98,18 @@ impl AccountsDb {
         // always insert the program_id of the instruction as the first account.
         let mut accounts =
             vec![(instruction.program_id, self.account_must(&instruction.program_id))];
-        instruction.accounts.iter().for_each(|meta| {
+        for meta in &instruction.accounts {
             if meta.pubkey == solana_sdk_ids::sysvar::instructions::id() {
                 // sysvar instructions needs to be handled specially
                 let account = SysvarInstructions::construct_instructions_account(instruction);
                 accounts.push((meta.pubkey, account));
-                return;
+                continue;
             }
-
-            let pubkey = meta.pubkey;
-            // first, check local cache
-            if let Some(account) = self.account_maybe(&pubkey) {
-                accounts.push((pubkey, account));
-                return;
-            }
-
-            // if account is not present in local cache, attempt to fetch from rpc
-            #[cfg(feature = "rpc-fetch")]
-            if self.scenario.rpc_enabled() {
-                if let Some(account) = self.scenario.try_fetch_from_rpc(&pubkey) {
-                    accounts.push((pubkey, account));
-                    return;
-                }
-            }
-
-            // finally, if still not found, handle according to allow_uninitialized_accounts
-            if allow_uninitialized_accounts {
-                log::debug!("Creating uninitialized account for {pubkey}");
-                accounts.push((pubkey, AccountSharedData::default()));
-                return;
-            }
-
-            panic!("Account not found for {pubkey}");
-        });
+            accounts.push((
+                meta.pubkey,
+                self.resolve_account(&meta.pubkey, allow_uninitialized_accounts),
+            ));
+        }
         accounts
     }
 

--- a/crates/seashell-core/src/accounts_db.rs
+++ b/crates/seashell-core/src/accounts_db.rs
@@ -31,7 +31,9 @@ pub struct AccountsDb {
 
 impl AccountsDb {
     pub fn clear_non_program_accounts(&self) {
-        self.accounts.write().retain(|_, account| account.executable());
+        self.accounts
+            .write()
+            .retain(|_, account| account.executable());
     }
 
     pub fn warp(&self, slot: u64, timestamp: i64) {

--- a/crates/seashell-core/src/compile.rs
+++ b/crates/seashell-core/src/compile.rs
@@ -5,19 +5,65 @@ use solana_transaction_context::{IndexOfAccount, InstructionAccount};
 
 pub const INSTRUCTION_PROGRAM_ID_INDEX: u16 = 0;
 
-pub fn compile_accounts_for_instruction(ixn: &Instruction) -> Vec<InstructionAccount> {
-    let mut account_map: IndexMap<Pubkey, (bool, bool)> = IndexMap::new();
-    account_map.insert(ixn.program_id, (false, false));
-
-    for account in &ixn.accounts {
-        account_map
-            .entry(account.pubkey)
+fn merge_account_privileges(ixn: &Instruction) -> IndexMap<Pubkey, (bool, bool)> {
+    let mut privileges: IndexMap<Pubkey, (bool, bool)> = IndexMap::new();
+    for meta in &ixn.accounts {
+        privileges
+            .entry(meta.pubkey)
             .and_modify(|e| {
-                e.0 |= account.is_signer;
-                e.1 |= account.is_writable;
+                e.0 |= meta.is_signer;
+                e.1 |= meta.is_writable;
             })
-            .or_insert((account.is_signer, account.is_writable));
+            .or_insert((meta.is_signer, meta.is_writable));
     }
+    privileges
+}
+
+/// Deduplicated account keys across all instructions, preserving order of first appearance.
+pub fn compile_transaction_account_keys(ixns: &[Instruction]) -> Vec<Pubkey> {
+    let mut seen: IndexMap<Pubkey, ()> = IndexMap::new();
+    for ixn in ixns {
+        seen.entry(ixn.program_id).or_insert(());
+        for meta in &ixn.accounts {
+            seen.entry(meta.pubkey).or_insert(());
+        }
+    }
+    seen.keys().copied().collect()
+}
+
+/// Like [`compile_accounts_for_instruction`], but indices reference a shared transaction account list.
+pub fn compile_instruction_for_transaction(
+    ixn: &Instruction,
+    transaction_account_keys: &[Pubkey],
+) -> (IndexOfAccount, Vec<InstructionAccount>) {
+    let program_id_index = transaction_account_keys
+        .iter()
+        .position(|k| *k == ixn.program_id)
+        .expect("program_id must be present in transaction_account_keys")
+        as IndexOfAccount;
+
+    let account_privileges = merge_account_privileges(ixn);
+
+    let instruction_accounts = ixn
+        .accounts
+        .iter()
+        .map(|meta| {
+            let tx_index = transaction_account_keys
+                .iter()
+                .position(|k| *k == meta.pubkey)
+                .expect("account must be present in transaction_account_keys")
+                as IndexOfAccount;
+            let (is_signer, is_writable) = account_privileges.get(&meta.pubkey).unwrap();
+            InstructionAccount::new(tx_index, *is_signer, *is_writable)
+        })
+        .collect();
+
+    (program_id_index, instruction_accounts)
+}
+
+pub fn compile_accounts_for_instruction(ixn: &Instruction) -> Vec<InstructionAccount> {
+    let mut account_map = merge_account_privileges(ixn);
+    account_map.entry(ixn.program_id).or_insert((false, false));
 
     let mut transaction_accounts = vec![ixn.program_id];
     for account_meta in &ixn.accounts {
@@ -220,5 +266,73 @@ mod tests {
         assert!(result[2].is_writable());
         assert!(result[5].is_signer());
         assert!(result[5].is_writable());
+    }
+
+    #[test]
+    fn test_compile_transaction_account_keys() {
+        let program_a = Pubkey::new_unique();
+        let program_b = Pubkey::new_unique();
+        let account1 = Pubkey::new_unique();
+        let account2 = Pubkey::new_unique();
+        let shared = Pubkey::new_unique();
+
+        let ix1 = Instruction {
+            program_id: program_a,
+            accounts: vec![AccountMeta::new(account1, true), AccountMeta::new(shared, false)],
+            data: vec![],
+        };
+        let ix2 = Instruction {
+            program_id: program_b,
+            accounts: vec![AccountMeta::new(account2, true), AccountMeta::new(shared, false)],
+            data: vec![],
+        };
+
+        let keys = compile_transaction_account_keys(&[ix1, ix2]);
+        // Deduplicated, order of first appearance
+        assert_eq!(keys.len(), 5); // program_a, account1, shared, program_b, account2
+        assert_eq!(keys[0], program_a);
+        assert_eq!(keys[1], account1);
+        assert_eq!(keys[2], shared);
+        assert_eq!(keys[3], program_b);
+        assert_eq!(keys[4], account2);
+    }
+
+    #[test]
+    fn test_compile_instruction_for_transaction() {
+        let program_a = Pubkey::new_unique();
+        let program_b = Pubkey::new_unique();
+        let account1 = Pubkey::new_unique();
+        let shared = Pubkey::new_unique();
+
+        let ix1 = Instruction {
+            program_id: program_a,
+            accounts: vec![AccountMeta::new(account1, true), AccountMeta::new(shared, false)],
+            data: vec![],
+        };
+        let ix2 = Instruction {
+            program_id: program_b,
+            accounts: vec![AccountMeta::new(shared, true)],
+            data: vec![],
+        };
+
+        let keys = compile_transaction_account_keys(&[ix1.clone(), ix2.clone()]);
+        // keys: [program_a(0), account1(1), shared(2), program_b(3)]
+
+        let (pid_idx1, accs1) = compile_instruction_for_transaction(&ix1, &keys);
+        assert_eq!(pid_idx1, 0); // program_a is at index 0
+        assert_eq!(accs1.len(), 2);
+        assert_eq!(accs1[0].index_in_transaction, 1); // account1
+        assert!(accs1[0].is_signer());
+        assert!(accs1[0].is_writable());
+        assert_eq!(accs1[1].index_in_transaction, 2); // shared
+        assert!(!accs1[1].is_signer());
+        assert!(accs1[1].is_writable());
+
+        let (pid_idx2, accs2) = compile_instruction_for_transaction(&ix2, &keys);
+        assert_eq!(pid_idx2, 3); // program_b is at index 3
+        assert_eq!(accs2.len(), 1);
+        assert_eq!(accs2[0].index_in_transaction, 2); // shared
+        assert!(accs2[0].is_signer());
+        assert!(accs2[0].is_writable());
     }
 }

--- a/crates/seashell-core/src/seashell.rs
+++ b/crates/seashell-core/src/seashell.rs
@@ -18,9 +18,13 @@ use solana_svm_timings::ExecuteTimings;
 use solana_transaction_context::{IndexOfAccount, TransactionContext};
 
 use crate::accounts_db::AccountsDb;
-use crate::compile::{compile_accounts_for_instruction, INSTRUCTION_PROGRAM_ID_INDEX};
+use crate::compile::{
+    compile_accounts_for_instruction, compile_instruction_for_transaction,
+    compile_transaction_account_keys, INSTRUCTION_PROGRAM_ID_INDEX,
+};
 use crate::error::SeashellError;
 use crate::scenario::Scenario;
+use crate::sysvar::SysvarInstructions;
 
 pub struct Config {
     pub memoize: bool,
@@ -365,6 +369,165 @@ impl Seashell {
         }
     }
 
+    /// Process multiple instructions atomically, as a single transaction.
+    ///
+    /// All instructions share one `TransactionContext`. If any instruction fails,
+    /// none of the changes are committed (even with `memoize` enabled).
+    pub fn process_instructions(&self, ixns: &[Instruction]) -> TransactionProcessingResult {
+        if ixns.is_empty() {
+            return TransactionProcessingResult {
+                total_compute_units_consumed: 0,
+                per_instruction_compute_units: vec![],
+                return_data: vec![],
+                error: None,
+                post_execution_accounts: vec![],
+            };
+        }
+
+        let transaction_account_keys = compile_transaction_account_keys(ixns);
+
+        let sysvar_instructions_id = solana_sdk_ids::sysvar::instructions::id();
+        let sysvar_instructions_account =
+            SysvarInstructions::construct_instructions_account_for_transaction(ixns);
+
+        let transaction_accounts: Vec<_> = transaction_account_keys
+            .iter()
+            .map(|pubkey| {
+                if *pubkey == sysvar_instructions_id {
+                    return (*pubkey, sysvar_instructions_account.clone());
+                }
+                // TODO: unlike process_instruction, this doesn't go through accounts_for_instruction
+                // so allow_uninitialized_accounts_local and RPC fallback are not honored here.
+                (*pubkey, self.accounts_db.account_must(pubkey))
+            })
+            .collect();
+
+        let sysvar_cache = self
+            .accounts_db
+            .sysvars_for_instruction(&transaction_accounts);
+
+        let mut transaction_context = TransactionContext::new(
+            transaction_accounts,
+            self.accounts_db.sysvars.rent(),
+            self.compute_budget.max_instruction_stack_depth,
+            self.compute_budget.max_instruction_trace_length,
+        );
+
+        let epoch_stake_callback = SeashellInvokeContextCallback { feature_set: &self.feature_set };
+        let runtime_features = self.feature_set.runtime_features();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+
+        let all_instruction_datas: Vec<&[u8]> = ixns.iter().map(|ix| ix.data.as_slice()).collect();
+        let mut programs = self.accounts_db.programs.clone();
+
+        let mut total_compute_units = 0u64;
+        let mut per_instruction_compute = Vec::with_capacity(ixns.len());
+
+        for (idx, ixn) in ixns.iter().enumerate() {
+            let (program_id_index, instruction_accounts) =
+                compile_instruction_for_transaction(ixn, &transaction_account_keys);
+
+            let mut dedup_map =
+                vec![u16::MAX; solana_transaction_context::MAX_ACCOUNTS_PER_TRANSACTION];
+            for (i, account) in instruction_accounts.iter().enumerate() {
+                let slot = dedup_map
+                    .get_mut(account.index_in_transaction as usize)
+                    .unwrap();
+                if *slot == u16::MAX {
+                    *slot = i as u16;
+                }
+            }
+
+            transaction_context
+                .configure_next_instruction(
+                    program_id_index,
+                    instruction_accounts,
+                    dedup_map,
+                    std::borrow::Cow::Borrowed(&ixn.data),
+                )
+                .expect("Failed to configure instruction");
+
+            let mut invoke_context = InvokeContext::new(
+                &mut transaction_context,
+                &mut programs,
+                EnvironmentConfig::new(
+                    Hash::default(),
+                    /* blockhash_lamports_per_signature */ 5000,
+                    &epoch_stake_callback,
+                    &runtime_features,
+                    &program_runtime_environments,
+                    &program_runtime_environments,
+                    &sysvar_cache,
+                ),
+                self.log_collector.clone(),
+                self.compute_budget.to_budget(),
+                self.compute_budget.to_cost(),
+            );
+
+            let mut compute_units_consumed = 0;
+
+            let result = if invoke_context.is_precompile(&ixn.program_id) {
+                invoke_context.process_precompile(
+                    &ixn.program_id,
+                    &ixn.data,
+                    all_instruction_datas.iter().copied(),
+                )
+            } else {
+                invoke_context.process_instruction(
+                    &mut compute_units_consumed,
+                    &mut ExecuteTimings::default(),
+                )
+            };
+
+            total_compute_units += compute_units_consumed;
+            per_instruction_compute.push(compute_units_consumed);
+
+            // Drop invoke_context to release &mut borrow on transaction_context.
+            drop(invoke_context);
+
+            if let Err(e) = result {
+                return TransactionProcessingResult {
+                    total_compute_units_consumed: total_compute_units,
+                    per_instruction_compute_units: per_instruction_compute,
+                    return_data: transaction_context.get_return_data().1.to_owned(),
+                    error: Some((idx, InstructionProcessingError::InstructionError(e))),
+                    post_execution_accounts: Vec::default(),
+                };
+            }
+        }
+
+        let return_data = transaction_context.get_return_data().1.to_owned();
+        let post_execution_accounts: Vec<(Pubkey, Account)> = transaction_account_keys
+            .iter()
+            .enumerate()
+            .map(|(idx, pubkey)| {
+                let accounts = transaction_context.accounts();
+                let account_ref = accounts
+                    .try_borrow(idx as IndexOfAccount)
+                    .expect("Failed to borrow TransactionAccounts");
+                let account = AccountSharedData::create(
+                    account_ref.lamports(),
+                    account_ref.data().to_vec(),
+                    *account_ref.owner(),
+                    account_ref.executable(),
+                    account_ref.rent_epoch(),
+                );
+                if self.config.memoize {
+                    self.set_account_from_account_shared_data(*pubkey, account.clone());
+                }
+                (*pubkey, account.into())
+            })
+            .collect();
+
+        TransactionProcessingResult {
+            total_compute_units_consumed: total_compute_units,
+            per_instruction_compute_units: per_instruction_compute,
+            return_data,
+            error: None,
+            post_execution_accounts,
+        }
+    }
+
     pub fn airdrop(&mut self, pubkey: Pubkey, amount: u64) {
         let mut account = self
             .accounts_db
@@ -399,6 +562,19 @@ pub struct InstructionProcessingResult {
     pub compute_units_consumed: u64,
     pub return_data: Vec<u8>,
     pub error: Option<InstructionProcessingError>,
+    pub post_execution_accounts: Vec<(Pubkey, Account)>,
+}
+
+pub struct TransactionProcessingResult {
+    /// Total compute units consumed across all instructions.
+    pub total_compute_units_consumed: u64,
+    /// Compute units consumed by each instruction individually.
+    pub per_instruction_compute_units: Vec<u64>,
+    /// Return data from the last successfully executed instruction.
+    pub return_data: Vec<u8>,
+    /// If an instruction failed: `(instruction_index, error)`. `None` if all succeeded.
+    pub error: Option<(usize, InstructionProcessingError)>,
+    /// Post-execution account states. Empty if any instruction failed (atomic rollback).
     pub post_execution_accounts: Vec<(Pubkey, Account)>,
 }
 
@@ -882,5 +1058,156 @@ mod tests {
             "Expected no return data, got: {:?}",
             result.return_data
         );
+    }
+
+    #[test]
+    fn test_process_instructions_native_transfer() {
+        crate::set_log();
+        let mut seashell = Seashell::new();
+
+        let alice = Pubkey::new_unique();
+        let bob = Pubkey::new_unique();
+        let carol = Pubkey::new_unique();
+        seashell.airdrop(alice, 1000);
+        seashell.accounts_db.set_account_mock(bob);
+        seashell.accounts_db.set_account_mock(carol);
+
+        // Two transfers in one atomic batch: alice->bob 600, alice->carol 400
+        let mut data1 = Vec::with_capacity(12);
+        data1.extend_from_slice(&2u32.to_le_bytes());
+        data1.extend_from_slice(&600u64.to_le_bytes());
+
+        let mut data2 = Vec::with_capacity(12);
+        data2.extend_from_slice(&2u32.to_le_bytes());
+        data2.extend_from_slice(&400u64.to_le_bytes());
+
+        let ix1 = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
+            data: data1,
+        };
+        let ix2 = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(carol, false)],
+            data: data2,
+        };
+
+        let result = seashell.process_instructions(&[ix1, ix2]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+        assert_eq!(result.per_instruction_compute_units.len(), 2);
+
+        let post_alice = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pk, _)| *pk == alice)
+            .unwrap()
+            .1
+            .clone();
+        let post_bob = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pk, _)| *pk == bob)
+            .unwrap()
+            .1
+            .clone();
+        let post_carol = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pk, _)| *pk == carol)
+            .unwrap()
+            .1
+            .clone();
+
+        assert_eq!(post_alice.lamports(), 0, "Alice should have 0 after sending 600+400");
+        assert_eq!(post_bob.lamports(), 600, "Bob should have 600");
+        assert_eq!(post_carol.lamports(), 400, "Carol should have 400");
+    }
+
+    #[test]
+    fn test_process_instructions_atomic_rollback() {
+        crate::set_log();
+        let mut seashell = Seashell::new_with_config(Config {
+            memoize: true,
+            allow_uninitialized_accounts_local: false,
+            allow_uninitialized_accounts_fetched: false,
+        });
+
+        let alice = Pubkey::new_unique();
+        let bob = Pubkey::new_unique();
+        seashell.airdrop(alice, 1000);
+        seashell.accounts_db.set_account_mock(bob);
+
+        // First instruction succeeds (transfer 600), second fails (transfer 600 again, but only 400 left)
+        let mut data1 = Vec::with_capacity(12);
+        data1.extend_from_slice(&2u32.to_le_bytes());
+        data1.extend_from_slice(&600u64.to_le_bytes());
+
+        let mut data2 = Vec::with_capacity(12);
+        data2.extend_from_slice(&2u32.to_le_bytes());
+        data2.extend_from_slice(&600u64.to_le_bytes());
+
+        let ix1 = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
+            data: data1,
+        };
+        let ix2 = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
+            data: data2,
+        };
+
+        let result = seashell.process_instructions(&[ix1, ix2]);
+        assert!(result.error.is_some(), "Second instruction should fail");
+        assert_eq!(result.error.as_ref().unwrap().0, 1, "Failure should be at index 1");
+
+        // With memoize=true, the accounts_db should NOT have been updated (atomic rollback).
+        let alice_account = seashell.account(&alice);
+        assert_eq!(
+            alice_account.lamports(),
+            1000,
+            "Alice should still have 1000 (no memoize on failure)"
+        );
+    }
+
+    #[test]
+    fn test_process_instructions_memoize() {
+        crate::set_log();
+        let mut seashell = Seashell::new_with_config(Config {
+            memoize: true,
+            allow_uninitialized_accounts_local: false,
+            allow_uninitialized_accounts_fetched: false,
+        });
+
+        let alice = Pubkey::new_unique();
+        let bob = Pubkey::new_unique();
+        seashell.airdrop(alice, 1000);
+        seashell.accounts_db.set_account_mock(bob);
+
+        let mut data = Vec::with_capacity(12);
+        data.extend_from_slice(&2u32.to_le_bytes());
+        data.extend_from_slice(&500u64.to_le_bytes());
+
+        let ix = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
+            data,
+        };
+
+        let result = seashell.process_instructions(&[ix]);
+        assert!(result.error.is_none());
+
+        // With memoize, accounts_db should reflect the changes.
+        assert_eq!(seashell.account(&alice).lamports(), 500);
+        assert_eq!(seashell.account(&bob).lamports(), 500);
+    }
+
+    #[test]
+    fn test_process_instructions_empty() {
+        let seashell = Seashell::new();
+        let result = seashell.process_instructions(&[]);
+        assert!(result.error.is_none());
+        assert_eq!(result.total_compute_units_consumed, 0);
+        assert!(result.post_execution_accounts.is_empty());
     }
 }

--- a/crates/seashell-core/src/seashell.rs
+++ b/crates/seashell-core/src/seashell.rs
@@ -396,9 +396,11 @@ impl Seashell {
                 if *pubkey == sysvar_instructions_id {
                     return (*pubkey, sysvar_instructions_account.clone());
                 }
-                // TODO: unlike process_instruction, this doesn't go through accounts_for_instruction
-                // so allow_uninitialized_accounts_local and RPC fallback are not honored here.
-                (*pubkey, self.accounts_db.account_must(pubkey))
+                (
+                    *pubkey,
+                    self.accounts_db
+                        .resolve_account(pubkey, self.config.allow_uninitialized_accounts_local),
+                )
             })
             .collect();
 
@@ -417,7 +419,6 @@ impl Seashell {
         let runtime_features = self.feature_set.runtime_features();
         let program_runtime_environments = ProgramRuntimeEnvironments::default();
 
-        let all_instruction_datas: Vec<&[u8]> = ixns.iter().map(|ix| ix.data.as_slice()).collect();
         let mut programs = self.accounts_db.programs.clone();
 
         let mut total_compute_units = 0u64;
@@ -467,11 +468,8 @@ impl Seashell {
             let mut compute_units_consumed = 0;
 
             let result = if invoke_context.is_precompile(&ixn.program_id) {
-                invoke_context.process_precompile(
-                    &ixn.program_id,
-                    &ixn.data,
-                    all_instruction_datas.iter().copied(),
-                )
+                let all_instruction_datas = ixns.iter().map(|ix| ix.data.as_slice());
+                invoke_context.process_precompile(&ixn.program_id, &ixn.data, all_instruction_datas)
             } else {
                 invoke_context.process_instruction(
                     &mut compute_units_consumed,
@@ -1065,62 +1063,81 @@ mod tests {
         crate::set_log();
         let mut seashell = Seashell::new();
 
-        let alice = Pubkey::new_unique();
-        let bob = Pubkey::new_unique();
-        let carol = Pubkey::new_unique();
-        seashell.airdrop(alice, 1000);
-        seashell.accounts_db.set_account_mock(bob);
-        seashell.accounts_db.set_account_mock(carol);
+        let from = solana_pubkey::Pubkey::new_unique();
+        let to_a = solana_pubkey::Pubkey::new_unique();
+        let to_b = solana_pubkey::Pubkey::new_unique();
+        seashell.airdrop(from, 1000);
+        seashell.accounts_db.set_account_mock(to_a);
+        seashell.accounts_db.set_account_mock(to_b);
+        println!("Airdropped 1000 lamports to {from}");
 
-        // Two transfers in one atomic batch: alice->bob 600, alice->carol 400
-        let mut data1 = Vec::with_capacity(12);
-        data1.extend_from_slice(&2u32.to_le_bytes());
-        data1.extend_from_slice(&600u64.to_le_bytes());
+        let mut data_a = Vec::with_capacity(12);
+        data_a.extend_from_slice(&2u32.to_le_bytes());
+        data_a.extend_from_slice(&600u64.to_le_bytes());
 
-        let mut data2 = Vec::with_capacity(12);
-        data2.extend_from_slice(&2u32.to_le_bytes());
-        data2.extend_from_slice(&400u64.to_le_bytes());
+        let mut data_b = Vec::with_capacity(12);
+        data_b.extend_from_slice(&2u32.to_le_bytes());
+        data_b.extend_from_slice(&400u64.to_le_bytes());
 
-        let ix1 = Instruction {
+        let ix_a = Instruction {
             program_id: solana_sdk_ids::system_program::id(),
-            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
-            data: data1,
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to_a, false)],
+            data: data_a,
         };
-        let ix2 = Instruction {
+        let ix_b = Instruction {
             program_id: solana_sdk_ids::system_program::id(),
-            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(carol, false)],
-            data: data2,
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to_b, false)],
+            data: data_b,
         };
 
-        let result = seashell.process_instructions(&[ix1, ix2]);
+        let result = seashell.process_instructions(&[ix_a, ix_b]);
         assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
         assert_eq!(result.per_instruction_compute_units.len(), 2);
 
-        let post_alice = result
+        let post_from = result
             .post_execution_accounts
             .iter()
-            .find(|(pk, _)| *pk == alice)
-            .unwrap()
-            .1
-            .clone();
-        let post_bob = result
-            .post_execution_accounts
-            .iter()
-            .find(|(pk, _)| *pk == bob)
-            .unwrap()
-            .1
-            .clone();
-        let post_carol = result
-            .post_execution_accounts
-            .iter()
-            .find(|(pk, _)| *pk == carol)
-            .unwrap()
-            .1
-            .clone();
+            .find(|(pubkey, _)| *pubkey == from)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_from.lamports(),
+            0,
+            "Expected from account to have 0 lamports after both transfers"
+        );
 
-        assert_eq!(post_alice.lamports(), 0, "Alice should have 0 after sending 600+400");
-        assert_eq!(post_bob.lamports(), 600, "Bob should have 600");
-        assert_eq!(post_carol.lamports(), 400, "Carol should have 400");
+        let post_to_a = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == to_a)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_to_a.lamports(),
+            600,
+            "Expected to_a account to have 600 lamports after transfer"
+        );
+
+        let post_to_b = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == to_b)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_to_b.lamports(),
+            400,
+            "Expected to_b account to have 400 lamports after transfer"
+        );
+
+        assert!(
+            result.return_data.is_empty(),
+            "Expected no return data, got: {:?}",
+            result.return_data
+        );
     }
 
     #[test]
@@ -1132,41 +1149,39 @@ mod tests {
             allow_uninitialized_accounts_fetched: false,
         });
 
-        let alice = Pubkey::new_unique();
-        let bob = Pubkey::new_unique();
-        seashell.airdrop(alice, 1000);
-        seashell.accounts_db.set_account_mock(bob);
+        let from = solana_pubkey::Pubkey::new_unique();
+        let to = solana_pubkey::Pubkey::new_unique();
+        seashell.airdrop(from, 1000);
+        seashell.accounts_db.set_account_mock(to);
 
-        // First instruction succeeds (transfer 600), second fails (transfer 600 again, but only 400 left)
-        let mut data1 = Vec::with_capacity(12);
-        data1.extend_from_slice(&2u32.to_le_bytes());
-        data1.extend_from_slice(&600u64.to_le_bytes());
+        let mut data_a = Vec::with_capacity(12);
+        data_a.extend_from_slice(&2u32.to_le_bytes());
+        data_a.extend_from_slice(&600u64.to_le_bytes());
 
-        let mut data2 = Vec::with_capacity(12);
-        data2.extend_from_slice(&2u32.to_le_bytes());
-        data2.extend_from_slice(&600u64.to_le_bytes());
+        let mut data_b = Vec::with_capacity(12);
+        data_b.extend_from_slice(&2u32.to_le_bytes());
+        data_b.extend_from_slice(&600u64.to_le_bytes());
 
-        let ix1 = Instruction {
+        let ix_a = Instruction {
             program_id: solana_sdk_ids::system_program::id(),
-            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
-            data: data1,
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
+            data: data_a,
         };
-        let ix2 = Instruction {
+        let ix_b = Instruction {
             program_id: solana_sdk_ids::system_program::id(),
-            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
-            data: data2,
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
+            data: data_b,
         };
 
-        let result = seashell.process_instructions(&[ix1, ix2]);
-        assert!(result.error.is_some(), "Second instruction should fail");
-        assert_eq!(result.error.as_ref().unwrap().0, 1, "Failure should be at index 1");
+        let result = seashell.process_instructions(&[ix_a, ix_b]);
+        assert!(result.error.is_some(), "Expected second instruction to fail");
+        assert_eq!(result.error.as_ref().unwrap().0, 1, "Expected failure index to be 1");
 
-        // With memoize=true, the accounts_db should NOT have been updated (atomic rollback).
-        let alice_account = seashell.account(&alice);
+        let post_from = seashell.account(&from);
         assert_eq!(
-            alice_account.lamports(),
+            post_from.lamports(),
             1000,
-            "Alice should still have 1000 (no memoize on failure)"
+            "Expected from account to still have 1000 lamports after atomic rollback"
         );
     }
 
@@ -1179,35 +1194,322 @@ mod tests {
             allow_uninitialized_accounts_fetched: false,
         });
 
-        let alice = Pubkey::new_unique();
-        let bob = Pubkey::new_unique();
-        seashell.airdrop(alice, 1000);
-        seashell.accounts_db.set_account_mock(bob);
+        let from = solana_pubkey::Pubkey::new_unique();
+        let to = solana_pubkey::Pubkey::new_unique();
+        seashell.airdrop(from, 1000);
+        seashell.accounts_db.set_account_mock(to);
 
         let mut data = Vec::with_capacity(12);
         data.extend_from_slice(&2u32.to_le_bytes());
         data.extend_from_slice(&500u64.to_le_bytes());
 
-        let ix = Instruction {
+        let ixn = Instruction {
             program_id: solana_sdk_ids::system_program::id(),
-            accounts: vec![AccountMeta::new(alice, true), AccountMeta::new(bob, false)],
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
             data,
         };
 
-        let result = seashell.process_instructions(&[ix]);
-        assert!(result.error.is_none());
+        let result = seashell.process_instructions(&[ixn]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
 
-        // With memoize, accounts_db should reflect the changes.
-        assert_eq!(seashell.account(&alice).lamports(), 500);
-        assert_eq!(seashell.account(&bob).lamports(), 500);
+        let post_from = seashell.account(&from);
+        assert_eq!(
+            post_from.lamports(),
+            500,
+            "Expected from account to have 500 lamports after transfer"
+        );
+
+        let post_to = seashell.account(&to);
+        assert_eq!(
+            post_to.lamports(),
+            500,
+            "Expected to account to have 500 lamports after transfer"
+        );
     }
 
     #[test]
     fn test_process_instructions_empty() {
         let seashell = Seashell::new();
         let result = seashell.process_instructions(&[]);
-        assert!(result.error.is_none());
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
         assert_eq!(result.total_compute_units_consumed, 0);
         assert!(result.post_execution_accounts.is_empty());
+    }
+
+    #[test]
+    fn test_process_instructions_allow_uninitialized_accounts() {
+        crate::set_log();
+        let mut seashell = Seashell::new_with_config(Config {
+            memoize: false,
+            allow_uninitialized_accounts_local: true,
+            allow_uninitialized_accounts_fetched: false,
+        });
+
+        let from = solana_pubkey::Pubkey::new_unique();
+        let to = solana_pubkey::Pubkey::new_unique();
+        seashell.airdrop(from, 1000);
+
+        let mut data = Vec::with_capacity(12);
+        data.extend_from_slice(&2u32.to_le_bytes());
+        data.extend_from_slice(&500u64.to_le_bytes());
+
+        let ixn = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
+            data,
+        };
+
+        let result = seashell.process_instructions(&[ixn]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+
+        let post_to = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == to)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_to.lamports(),
+            500,
+            "Expected to account to have 500 lamports after transfer"
+        );
+    }
+
+    #[test]
+    fn test_process_instructions_precompile() {
+        const MESSAGE_LENGTH: usize = 128;
+        crate::set_log();
+        let mut seashell = Seashell::new();
+
+        use rand::{thread_rng, Rng};
+        let mut rng = thread_rng();
+
+        let from = solana_pubkey::Pubkey::new_unique();
+        let to = solana_pubkey::Pubkey::new_unique();
+        seashell.airdrop(from, 1000);
+        seashell.accounts_db.set_account_mock(to);
+
+        let mut transfer_data = Vec::with_capacity(12);
+        transfer_data.extend_from_slice(&2u32.to_le_bytes());
+        transfer_data.extend_from_slice(&500u64.to_le_bytes());
+
+        let transfer_ixn = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
+            data: transfer_data,
+        };
+
+        use ed25519_dalek::Signer;
+        let privkey = ed25519_dalek::Keypair::generate(&mut rng);
+        let message: Vec<u8> = (0..MESSAGE_LENGTH).map(|_| rng.gen_range(0, 255)).collect();
+        let signature = privkey.sign(&message).to_bytes();
+        let pubkey = privkey.public.to_bytes();
+        let ed25519_ixn = solana_ed25519_program::new_ed25519_instruction_with_signature(
+            &message, &signature, &pubkey,
+        );
+
+        let result = seashell.process_instructions(&[transfer_ixn, ed25519_ixn]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+        assert_eq!(result.per_instruction_compute_units.len(), 2);
+        assert_eq!(
+            result.per_instruction_compute_units[1], 0,
+            "Expected ed25519 precompile to consume 0 compute units"
+        );
+
+        let post_from = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == from)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_from.lamports(),
+            500,
+            "Expected from account to have 500 lamports after transfer"
+        );
+    }
+
+    #[test]
+    fn test_process_instructions_cpi_via_ata_program() {
+        crate::set_log();
+        let mut seashell = Seashell::new();
+
+        let payer = solana_pubkey::Pubkey::new_unique();
+        let mint = solana_pubkey::Pubkey::new_unique();
+        let mint_authority = solana_pubkey::Pubkey::new_unique();
+        let wallet = solana_pubkey::Pubkey::new_unique();
+
+        const MINT_LEN: u64 = 82;
+        const MINT_RENT: u64 = 1_461_600;
+        const TOKEN_ACCOUNT_LEN: usize = 165;
+
+        seashell.airdrop(payer, 10_000_000);
+        seashell.accounts_db.set_account_mock(wallet);
+        seashell
+            .accounts_db
+            .set_account(mint, AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id()));
+
+        let (ata, _) = Pubkey::find_program_address(
+            &[wallet.as_ref(), crate::spl::TOKEN_PROGRAM_ID.as_ref(), mint.as_ref()],
+            &crate::spl::ASSOCIATED_TOKEN_PROGRAM_ID,
+        );
+        seashell
+            .accounts_db
+            .set_account(ata, AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id()));
+
+        let mut create_mint_data = Vec::with_capacity(52);
+        create_mint_data.extend_from_slice(&0u32.to_le_bytes());
+        create_mint_data.extend_from_slice(&MINT_RENT.to_le_bytes());
+        create_mint_data.extend_from_slice(&MINT_LEN.to_le_bytes());
+        create_mint_data.extend_from_slice(&crate::spl::TOKEN_PROGRAM_ID.to_bytes());
+
+        let create_mint_ixn = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(payer, true), AccountMeta::new(mint, true)],
+            data: create_mint_data,
+        };
+
+        let mut init_mint_data = Vec::with_capacity(35);
+        init_mint_data.push(20);
+        init_mint_data.push(6);
+        init_mint_data.extend_from_slice(&mint_authority.to_bytes());
+        init_mint_data.push(0);
+
+        let init_mint_ixn = Instruction {
+            program_id: crate::spl::TOKEN_PROGRAM_ID,
+            accounts: vec![AccountMeta::new(mint, false)],
+            data: init_mint_data,
+        };
+
+        let create_ata_ixn = Instruction {
+            program_id: crate::spl::ASSOCIATED_TOKEN_PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(ata, false),
+                AccountMeta::new_readonly(wallet, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(solana_sdk_ids::system_program::id(), false),
+                AccountMeta::new_readonly(crate::spl::TOKEN_PROGRAM_ID, false),
+            ],
+            data: vec![],
+        };
+
+        let result =
+            seashell.process_instructions(&[create_mint_ixn, init_mint_ixn, create_ata_ixn]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+        assert_eq!(result.per_instruction_compute_units.len(), 3);
+
+        let post_ata = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == ata)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_ata.owner,
+            crate::spl::TOKEN_PROGRAM_ID,
+            "Expected ATA account to be owned by the token program"
+        );
+        assert_eq!(
+            post_ata.data.len(),
+            TOKEN_ACCOUNT_LEN,
+            "Expected ATA account to have token-account-sized data"
+        );
+        assert_eq!(
+            &post_ata.data[0..32],
+            &mint.to_bytes(),
+            "Expected ATA mint field to match mint pubkey"
+        );
+        assert_eq!(
+            &post_ata.data[32..64],
+            &wallet.to_bytes(),
+            "Expected ATA owner field to match wallet pubkey"
+        );
+    }
+
+    #[test]
+    fn test_process_instructions_create_and_init_mint() {
+        crate::set_log();
+        let mut seashell = Seashell::new();
+
+        let payer = solana_pubkey::Pubkey::new_unique();
+        let mint = solana_pubkey::Pubkey::new_unique();
+        let mint_authority = solana_pubkey::Pubkey::new_unique();
+
+        const MINT_LEN: u64 = 82;
+        const MINT_RENT: u64 = 1_461_600;
+
+        seashell.airdrop(payer, 10_000_000);
+        seashell
+            .accounts_db
+            .set_account(mint, AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id()));
+
+        let mut create_data = Vec::with_capacity(52);
+        create_data.extend_from_slice(&0u32.to_le_bytes());
+        create_data.extend_from_slice(&MINT_RENT.to_le_bytes());
+        create_data.extend_from_slice(&MINT_LEN.to_le_bytes());
+        create_data.extend_from_slice(&crate::spl::TOKEN_PROGRAM_ID.to_bytes());
+
+        let create_ixn = Instruction {
+            program_id: solana_sdk_ids::system_program::id(),
+            accounts: vec![AccountMeta::new(payer, true), AccountMeta::new(mint, true)],
+            data: create_data,
+        };
+
+        let mut init_data = Vec::with_capacity(35);
+        init_data.push(20);
+        init_data.push(6);
+        init_data.extend_from_slice(&mint_authority.to_bytes());
+        init_data.push(0);
+
+        let init_ixn = Instruction {
+            program_id: crate::spl::TOKEN_PROGRAM_ID,
+            accounts: vec![AccountMeta::new(mint, false)],
+            data: init_data,
+        };
+
+        let result = seashell.process_instructions(&[create_ixn, init_ixn]);
+        assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+        assert_eq!(result.per_instruction_compute_units.len(), 2);
+
+        let post_mint = result
+            .post_execution_accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == mint)
+            .expect("Resulting account should exist")
+            .to_owned()
+            .1;
+        assert_eq!(
+            post_mint.owner,
+            crate::spl::TOKEN_PROGRAM_ID,
+            "Expected mint account to be owned by the token program"
+        );
+        assert_eq!(post_mint.lamports, MINT_RENT, "Expected mint account to be funded with rent");
+        assert_eq!(
+            post_mint.data.len(),
+            MINT_LEN as usize,
+            "Expected mint account to have mint-sized data"
+        );
+        assert_eq!(
+            &post_mint.data[0..4],
+            &1u32.to_le_bytes(),
+            "Expected mint_authority COption tag to be Some"
+        );
+        assert_eq!(
+            &post_mint.data[4..36],
+            &mint_authority.to_bytes(),
+            "Expected mint_authority pubkey to match"
+        );
+        assert_eq!(&post_mint.data[36..44], &0u64.to_le_bytes(), "Expected mint supply to be 0");
+        assert_eq!(post_mint.data[44], 6, "Expected mint decimals to be 6");
+        assert_eq!(post_mint.data[45], 1, "Expected mint is_initialized to be true");
+        assert_eq!(
+            &post_mint.data[46..50],
+            &0u32.to_le_bytes(),
+            "Expected freeze_authority COption tag to be None"
+        );
     }
 }

--- a/crates/seashell-core/src/spl/mod.rs
+++ b/crates/seashell-core/src/spl/mod.rs
@@ -17,8 +17,5 @@ pub fn load(seashell: &mut Seashell) {
 }
 
 pub fn load_p_token(seashell: &mut Seashell) {
-    seashell.load_program_from_bytes(
-        TOKEN_PROGRAM_ID,
-        include_bytes!("elfs/ptoken.so"),
-    );
+    seashell.load_program_from_bytes(TOKEN_PROGRAM_ID, include_bytes!("elfs/ptoken.so"));
 }

--- a/crates/seashell-core/src/sysvar.rs
+++ b/crates/seashell-core/src/sysvar.rs
@@ -158,21 +158,32 @@ pub struct SysvarInstructions;
 
 impl SysvarInstructions {
     pub fn construct_instructions_account(instruction: &Instruction) -> AccountSharedData {
-        let borrowed_accounts = instruction.accounts.iter().map(|meta| {
-            BorrowedAccountMeta {
-                pubkey: &meta.pubkey,
-                is_signer: meta.is_signer,
-                is_writable: meta.is_writable,
-            }
-        }).collect::<Vec<_>>();
+        Self::construct_instructions_account_for_transaction(std::slice::from_ref(instruction))
+    }
 
-        let borrowed_instruction = BorrowedInstruction {
-            program_id: &instruction.program_id,
-            accounts: borrowed_accounts,
-            data: &instruction.data,
-        };
+    /// Build the sysvar instructions account from all instructions in a transaction.
+    pub fn construct_instructions_account_for_transaction(
+        instructions: &[Instruction],
+    ) -> AccountSharedData {
+        let borrowed_instructions: Vec<_> = instructions
+            .iter()
+            .map(|ixn| BorrowedInstruction {
+                program_id: &ixn.program_id,
+                accounts: ixn
+                    .accounts
+                    .iter()
+                    .map(|meta| BorrowedAccountMeta {
+                        pubkey: &meta.pubkey,
+                        is_signer: meta.is_signer,
+                        is_writable: meta.is_writable,
+                    })
+                    .collect(),
+                data: &ixn.data,
+            })
+            .collect();
 
-        let sysvar_instructions_data = solana_instructions_sysvar::construct_instructions_data(&[borrowed_instruction]);
+        let sysvar_instructions_data =
+            solana_instructions_sysvar::construct_instructions_data(&borrowed_instructions);
 
         AccountSharedData::from(Account {
             data: sysvar_instructions_data,

--- a/crates/seashell-core/tests/process_instructions_sysvar.rs
+++ b/crates/seashell-core/tests/process_instructions_sysvar.rs
@@ -1,0 +1,55 @@
+use seashell::{try_find_workspace_root, Seashell};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+#[test]
+fn test_process_instructions_sysvar_instructions_current_index() {
+    let mut seashell = Seashell::new();
+    seashell.enable_log_collector();
+
+    let sysvar_ixns_so = try_find_workspace_root()
+        .unwrap()
+        .join("programs/sysvar_ixns/target/deploy/sysvar_ixns.so");
+    let program_bytes = std::fs::read(&sysvar_ixns_so)
+        .expect("sysvar_ixns.so not built; run `cargo build-sbf` in programs/sysvar_ixns");
+    let program_id = Pubkey::new_unique();
+    seashell.load_program_from_bytes(program_id, &program_bytes);
+
+    let from = Pubkey::new_unique();
+    let to = Pubkey::new_unique();
+    seashell.airdrop(from, 1000);
+    seashell.accounts_db.set_account_mock(to);
+
+    let mut transfer_data = Vec::with_capacity(12);
+    transfer_data.extend_from_slice(&2u32.to_le_bytes());
+    transfer_data.extend_from_slice(&500u64.to_le_bytes());
+
+    let transfer_ixn = Instruction {
+        program_id: solana_sdk_ids::system_program::id(),
+        accounts: vec![AccountMeta::new(from, true), AccountMeta::new(to, false)],
+        data: transfer_data,
+    };
+
+    let sysvar_ixns_ixn = Instruction {
+        program_id,
+        accounts: vec![AccountMeta::new_readonly(
+            solana_sdk_ids::sysvar::instructions::id(),
+            false,
+        )],
+        data: Vec::new(),
+    };
+
+    let result = seashell.process_instructions(&[transfer_ixn, sysvar_ixns_ixn]);
+    assert!(result.error.is_none(), "Expected no error, got: {:?}", result.error);
+    assert_eq!(result.per_instruction_compute_units.len(), 2);
+
+    let logs = seashell
+        .logs()
+        .expect("Expected log collector to be enabled");
+    let program_id_base58 = program_id.to_string();
+    assert!(
+        logs.iter().any(|line| line.contains(&program_id_base58)),
+        "Expected logs to contain sysvar_ixns program_id (proving sysvar::instructions \
+         current index was updated to 1). Logs: {logs:#?}"
+    );
+}

--- a/crates/seashell-core/tests/sysvar_ixns.rs
+++ b/crates/seashell-core/tests/sysvar_ixns.rs
@@ -16,9 +16,8 @@ fn test_sysvar_ixns() {
 
     seashell.enable_log_collector();
 
-    let accounts = vec![
-        AccountMeta::new_readonly(solana_sdk_ids::sysvar::instructions::id(), false),
-    ];
+    let accounts =
+        vec![AccountMeta::new_readonly(solana_sdk_ids::sysvar::instructions::id(), false)];
 
     let ixn = Instruction { program_id, accounts, data: Vec::new() };
 


### PR DESCRIPTION
* Currently Seashell supports only single ix via `process_instruction`. This PR adds support for multi ix via `process_instructions` sharing same `TransactionContext`,  while 100% backwards compatible, with no API signature changes.

* Tests added cover: cpi, precompiles, sysvar introspection, uninitialized accounts and atomic rollback 

* For future consideration: `process_instruction` could be reimplemented as a wrapper around `process_instructions` 

