### PR TITLE
fix: rename sysvar_ixns.rs to match toml file 

### DIFF
--- a/crates/seashell-core/src/accounts_db.rs
+++ b/crates/seashell-core/src/accounts_db.rs
@@ -31,7 +31,9 @@ pub struct AccountsDb {
 
 impl AccountsDb {
     pub fn clear_non_program_accounts(&self) {
-        self.accounts.write().retain(|_, account| account.executable());
+        self.accounts
+            .write()
+            .retain(|_, account| account.executable());
     }
 
     pub fn warp(&self, slot: u64, timestamp: i64) {

--- a/crates/seashell-core/src/spl/mod.rs
+++ b/crates/seashell-core/src/spl/mod.rs
@@ -17,8 +17,5 @@ pub fn load(seashell: &mut Seashell) {
 }
 
 pub fn load_p_token(seashell: &mut Seashell) {
-    seashell.load_program_from_bytes(
-        TOKEN_PROGRAM_ID,
-        include_bytes!("elfs/ptoken.so"),
-    );
+    seashell.load_program_from_bytes(TOKEN_PROGRAM_ID, include_bytes!("elfs/ptoken.so"));
 }

--- a/crates/seashell-core/src/sysvar.rs
+++ b/crates/seashell-core/src/sysvar.rs
@@ -158,13 +158,15 @@ pub struct SysvarInstructions;
 
 impl SysvarInstructions {
     pub fn construct_instructions_account(instruction: &Instruction) -> AccountSharedData {
-        let borrowed_accounts = instruction.accounts.iter().map(|meta| {
-            BorrowedAccountMeta {
+        let borrowed_accounts = instruction
+            .accounts
+            .iter()
+            .map(|meta| BorrowedAccountMeta {
                 pubkey: &meta.pubkey,
                 is_signer: meta.is_signer,
                 is_writable: meta.is_writable,
-            }
-        }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         let borrowed_instruction = BorrowedInstruction {
             program_id: &instruction.program_id,
@@ -172,7 +174,8 @@ impl SysvarInstructions {
             data: &instruction.data,
         };
 
-        let sysvar_instructions_data = solana_instructions_sysvar::construct_instructions_data(&[borrowed_instruction]);
+        let sysvar_instructions_data =
+            solana_instructions_sysvar::construct_instructions_data(&[borrowed_instruction]);
 
         AccountSharedData::from(Account {
             data: sysvar_instructions_data,

--- a/crates/seashell-core/tests/sysvar-ixns.rs
+++ b/crates/seashell-core/tests/sysvar-ixns.rs
@@ -16,9 +16,8 @@ fn test_sysvar_ixns() {
 
     seashell.enable_log_collector();
 
-    let accounts = vec![
-        AccountMeta::new_readonly(solana_sdk_ids::sysvar::instructions::id(), false),
-    ];
+    let accounts =
+        vec![AccountMeta::new_readonly(solana_sdk_ids::sysvar::instructions::id(), false)];
 
     let ixn = Instruction { program_id, accounts, data: Vec::new() };
 


### PR DESCRIPTION
* Cargo.toml declares test as sysvar-ixns.rs but currently test is sysvar_ixns.rs so cargo doesn't find it

* cargo +nightly fmt currently fails on missing test target

* Re-enables a previously unreachable integration test, so you may need to run cargo build-sbf in programs/sysvar_ixns/ before cargo test

* Also includes `cargo +nightly fmt` cleanups in a few adjacent files