### PR TITLE
feat(core): implement new default rpc-fetch feature

### DIFF
--- a/crates/seashell-core/Cargo.toml
+++ b/crates/seashell-core/Cargo.toml
@@ -46,8 +46,8 @@ solana-precompile-error.workspace = true
 solana-program-runtime.workspace = true
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
-solana-rpc-client = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+solana-rpc-client = { workspace = true, optional = true }
+solana-rpc-client-api = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-stake-interface = { workspace = true }
@@ -68,3 +68,7 @@ solana-ed25519-program = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-secp256r1-program = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+default = ["rpc-fetch"]
+rpc-fetch = ["dep:solana-rpc-client", "dep:solana-rpc-client-api"]

--- a/crates/seashell-core/src/accounts_db.rs
+++ b/crates/seashell-core/src/accounts_db.rs
@@ -58,9 +58,16 @@ impl AccountsDb {
 
     pub fn account_must(&self, pubkey: &Pubkey) -> AccountSharedData {
         self.account_maybe(pubkey).unwrap_or_else(|| {
-            self.scenario
-                .try_fetch_from_rpc(pubkey)
-                .expect("Account not found")
+            #[cfg(feature = "rpc-fetch")]
+            {
+                self.scenario
+                    .try_fetch_from_rpc(pubkey)
+                    .expect("Account not found")
+            }
+            #[cfg(not(feature = "rpc-fetch"))]
+            {
+                panic!("Account not found for {pubkey}")
+            }
         })
     }
 
@@ -89,6 +96,7 @@ impl AccountsDb {
             }
 
             // if account is not present in local cache, attempt to fetch from rpc
+            #[cfg(feature = "rpc-fetch")]
             if self.scenario.rpc_enabled() {
                 if let Some(account) = self.scenario.try_fetch_from_rpc(&pubkey) {
                     accounts.push((pubkey, account));

--- a/crates/seashell-core/src/scenario.rs
+++ b/crates/seashell-core/src/scenario.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use solana_account::{Account, AccountSharedData};
 use solana_pubkey::Pubkey;
+#[cfg(feature = "rpc-fetch")]
 use solana_rpc_client::rpc_client::RpcClient;
 
 /// Scenario manages account overrides with automatic persistence.
@@ -20,10 +21,12 @@ use solana_rpc_client::rpc_client::RpcClient;
 #[derive(Default)]
 pub struct Scenario {
     should_persist: Cell<bool>,
+    #[cfg_attr(not(feature = "rpc-fetch"), allow(dead_code))]
     pub(crate) allow_uninitialized_accounts: bool,
     dirty: Cell<bool>,
     data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
     path: Option<PathBuf>,
+    #[cfg(feature = "rpc-fetch")]
     rpc_client: Option<RpcClient>,
 }
 
@@ -100,11 +103,13 @@ impl Scenario {
             dirty: Cell::new(false),
             data: Arc::new(RwLock::new(data)),
             path: Some(path),
+            #[cfg(feature = "rpc-fetch")]
             rpc_client: None,
         }
     }
 
     /// Load a scenario with RPC fallback enabled.
+    #[cfg(feature = "rpc-fetch")]
     pub fn from_file_with_rpc(
         path: PathBuf,
         rpc_url: String,
@@ -115,6 +120,7 @@ impl Scenario {
         scenario
     }
 
+    #[cfg(feature = "rpc-fetch")]
     pub fn rpc_only(rpc_url: String, allow_uninitialized_accounts: bool) -> Self {
         Scenario {
             should_persist: Cell::new(false),
@@ -128,10 +134,12 @@ impl Scenario {
 
     /// Fetch an account from RPC and store it in the scenario.
     /// Panics if RPC is not configured or if the RPC request fails.
+    #[cfg(feature = "rpc-fetch")]
     pub fn must_fetch_from_rpc(&self, pubkey: &Pubkey) -> AccountSharedData {
         self.try_fetch_from_rpc(pubkey).unwrap()
     }
 
+    #[cfg(feature = "rpc-fetch")]
     pub fn try_fetch_from_rpc(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         log::debug!("Attempting to fetch account: {pubkey}");
         let rpc_client = self.rpc_client.as_ref().expect(
@@ -169,8 +177,17 @@ impl Scenario {
         self.data.write().insert(pubkey, account);
     }
 
+    /// Returns whether RPC fallback is configured. Always `false` when the
+    /// `rpc-fetch` feature is disabled.
     pub fn rpc_enabled(&self) -> bool {
-        self.rpc_client.is_some()
+        #[cfg(feature = "rpc-fetch")]
+        {
+            self.rpc_client.is_some()
+        }
+        #[cfg(not(feature = "rpc-fetch"))]
+        {
+            false
+        }
     }
 }
 

--- a/crates/seashell-core/src/seashell.rs
+++ b/crates/seashell-core/src/seashell.rs
@@ -203,21 +203,39 @@ impl Seashell {
             .map(String::from)
             .or_else(|| std::env::var("RPC_URL").ok());
 
-        self.accounts_db.scenario = if let Some(rpc_url) = resolved_rpc_url {
-            Scenario::from_file_with_rpc(
+        #[cfg(feature = "rpc-fetch")]
+        {
+            self.accounts_db.scenario = if let Some(rpc_url) = resolved_rpc_url {
+                Scenario::from_file_with_rpc(
+                    scenario_path,
+                    rpc_url,
+                    self.config.allow_uninitialized_accounts_fetched,
+                )
+            } else {
+                Scenario::from_file(scenario_path, self.config.allow_uninitialized_accounts_fetched)
+            };
+        }
+
+        #[cfg(not(feature = "rpc-fetch"))]
+        {
+            assert!(
+                resolved_rpc_url.is_none(),
+                "an rpc_url was provided (or `RPC_URL` env var is set) but the `rpc-fetch` \
+                 feature is disabled. Enable the `rpc-fetch` feature to fetch missing accounts \
+                 from RPC."
+            );
+            self.accounts_db.scenario = Scenario::from_file(
                 scenario_path,
-                rpc_url,
                 self.config.allow_uninitialized_accounts_fetched,
-            )
-        } else {
-            Scenario::from_file(scenario_path, self.config.allow_uninitialized_accounts_fetched)
-        };
+            );
+        }
     }
 
     /// Loads a temporary scenario that fetches accounts from RPC without persisting to disk.
     ///
     /// If `rpc_url` is provided, uses that endpoint.
     /// If `rpc_url` is `None`, falls back to the `RPC_URL` environment variable.
+    #[cfg(feature = "rpc-fetch")]
     pub fn load_temporary_scenario(&mut self, rpc_url: Option<&str>) {
         let resolved_rpc_url = rpc_url
             .map(String::from)


### PR DESCRIPTION
- Motivation: when testing programs where we don't need RPC, or when using cached scenarios, we can save decently.
- Makes `solana-rpc-client` + `solana-rpc-client-api` optional behind a new `rpc-fetch` feature, on by default.
- Reduces crate count and build time by around 32%. Reduces target size by around 44%.